### PR TITLE
Add optional schema exclusion parameters to maintenance operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,3 +142,9 @@ Running with dbt=0.14.2
 06:35:33 + 2 of 478 Analyzing "analytics"."customer_payments"
 06:35:33 + 2 of 478 Finished "analytics"."customer_payments" in 0.28s
 ```
+
+The command can also be run with optional parameters to exclude schemas, either with exact or regex matching. This can be useful for cases where the models (or the schemas themselves) tend to be short-lived and don't require vacuuming. For example:
+```
+$ dbt run-operation redshift_maintenance --args '{exclude_schemas: ["looker_scratch"], exclude_schemas_like: ["sinter_pr_%"]}'
+```
+

--- a/README.md
+++ b/README.md
@@ -145,6 +145,6 @@ Running with dbt=0.14.2
 
 The command can also be run with optional parameters to exclude schemas, either with exact or regex matching. This can be useful for cases where the models (or the schemas themselves) tend to be short-lived and don't require vacuuming. For example:
 ```
-$ dbt run-operation redshift_maintenance --args '{exclude_schemas: ["looker_scratch"], exclude_schemas_like: ["sinter_pr_%"]}'
+$ dbt run-operation redshift_maintenance --args '{exclude_schemas: ["looker_scratch"], exclude_schemas_like: ["sinter\\_pr\\_%"]}'
 ```
 


### PR DESCRIPTION
We've found it very helpful to exclude a couple schemas from the redshift maintenance operation -- in particular, in some schemas (e.g., the dbt PR or looker PDT schemas) tables can be dropped in between the initial results returned by `get_vacuumable_tables()` and the actual vacuum / analyze calls, causing errors and an abrupt end.

Since there's no "`VACUUM if exists`" option, our solution here is to introduce two new parameters to exact- and regex-match against schemas to exclude from the `get_vacuumable_tables()` results. We thought this might be helpful to the broader audience -- if this seems useful, LMK if there's anything else needed to make progress here :)