### PR TITLE
Improve redshift_maintenance macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,4 +147,17 @@ The command can also be run with optional parameters to exclude schemas, either 
 ```
 $ dbt run-operation redshift_maintenance --args '{exclude_schemas: ["looker_scratch"], exclude_schemas_like: ["sinter\\_pr\\_%"]}'
 ```
+You can also implement your own query to choose which tables to vacuum. To do so,
+create a macro in your **own project** named `vacuumable_tables_sql`, following
+the same pattern as the macro in [this package](macros/redshift_maintenance_operation.sql):
+```sql
+-- my_project/macros/redshift_maintenance_operation.sql
+select
+    '"' || table_schema || '"."' || table_name || '"' as table_name
+from information_schema.tables
+where table_type = 'BASE TABLE'
+    and table_schema not in ('information_schema', 'pg_catalog')
+    -- write your own contraints here
+order by table_schema, table_name
 
+```

--- a/README.md
+++ b/README.md
@@ -163,7 +163,10 @@ where table_type = 'BASE TABLE'
 order by table_schema, table_name
 
 ```
-This macro will skip any relations that are dropped in the time betwen running
+When you run the `redshift_maintenance` macro, your version of `vacuumable_tables_sql`
+will be respected.
+
+Note: This macro will skip any relations that are dropped in the time betwen running
 the initial query, and the point at which you try to vacuum it. This results in
 a message like so:
 ```

--- a/README.md
+++ b/README.md
@@ -153,11 +153,13 @@ the same pattern as the macro in [this package](macros/redshift_maintenance_oper
 ```sql
 -- my_project/macros/redshift_maintenance_operation.sql
 select
-    '"' || table_schema || '"."' || table_name || '"' as table_name
+  current_database() as table_database,
+  table_schema,
+  table_name
 from information_schema.tables
 where table_type = 'BASE TABLE'
     and table_schema not in ('information_schema', 'pg_catalog')
-    -- write your own contraints here
+    -- write your own constraints here
 order by table_schema, table_name
 
 ```

--- a/README.md
+++ b/README.md
@@ -163,3 +163,9 @@ where table_type = 'BASE TABLE'
 order by table_schema, table_name
 
 ```
+This macro will skip any relations that are dropped in the time betwen running
+the initial query, and the point at which you try to vacuum it. This results in
+a message like so:
+```
+13:18:22 + 1 of 157 Relation "analytics"."dbt_claire"."amazon_orders" does not exist
+```

--- a/macros/redshift_maintenance_operation.sql
+++ b/macros/redshift_maintenance_operation.sql
@@ -1,26 +1,43 @@
+{% macro vacuumable_tables_sql(exclude_schemas, exclude_schemas_like) %}
+    select
+        '"' || table_schema || '"."' || table_name || '"' as table_name
+    from information_schema.tables
+    where table_type = 'BASE TABLE'
+        and table_schema not in ('information_schema', 'pg_catalog')
+        {% if exclude_schemas %}
+        and table_schema not in ('{{exclude_schemas | join("', '")}}')
+        {% endif %}
+        {% for exclude_schema_like in exclude_schemas_like %}
+        and table_schema not like '{{ exclude_schema_like }}'
+        {% endfor %}
+    order by table_schema, table_name
+{% endmacro %}
+
 {% macro get_vacuumable_tables(exclude_schemas, exclude_schemas_like) %}
-    {% set vacuumable_tables_sql %}
-        select
-            '"' || table_schema || '"."' || table_name || '"' as table_name
-        from information_schema.tables
-        where table_type = 'BASE TABLE'
-            and table_schema not in ('information_schema', 'pg_catalog')
-            {% if exclude_schemas %}
-            and table_schema not in ('{{exclude_schemas | join("', '")}}')
-            {% endif %}
-            {% for exclude_schema_like in exclude_schemas_like %}
-            and table_schema not like '{{ exclude_schema_like }}'
-            {% endfor %}
-        order by table_schema, table_name
-    {% endset %}
-    {% set vacuumable_tables=run_query(vacuumable_tables_sql) %}
+
+    {% set vacuumable_tables=run_query(vacuumable_tables_sql()) %}
     {{ return(vacuumable_tables.columns[0].values()) }}
 
 {% endmacro %}
 
 {% macro redshift_maintenance(exclude_schemas=[], exclude_schemas_like=[]) %}
 
-    {% for table in get_vacuumable_tables(exclude_schemas, exclude_schemas_like) %}
+    {#-
+    This logic means that if you add your own macro named `vacuumable_tables_sql`
+    to your project, that will be used, giving you the flexibility of defining
+    your own query.
+    -#}
+    {% if context.get(ref.config.project_name, {}).get('vacuumable_tables_sql')  %}
+        {% set vacuumable_tables_sql=context[ref.config.project_name].vacuumable_tables_sql(exclude_schemas, exclude_schemas_like) %}
+    {% else %}
+        {% set vacuumable_tables_sql=redshift.vacuumable_tables_sql(exclude_schemas, exclude_schemas_like) %}
+    {% endif %}
+
+    {% set vacuumable_tables=run_query(vacuumable_tables_sql) %}
+
+    {% set vacummable_tables_list=vacuumable_tables.columns[0].values()  %}
+
+    {% for table in vacummable_tables_list %}
         {% set start=modules.datetime.datetime.now() %}
         {% set message_prefix=loop.index ~ " of " ~ loop.length %}
         {{ dbt_utils.log_info(message_prefix ~ " Vacuuming " ~ table) }}

--- a/macros/redshift_maintenance_operation.sql
+++ b/macros/redshift_maintenance_operation.sql
@@ -1,7 +1,7 @@
 {% macro vacuumable_tables_sql(exclude_schemas, exclude_schemas_like) %}
     select
         current_database() as table_database,
-        table_schema,
+        'foo' as table_schema,
         table_name
     from information_schema.tables
     where table_type = 'BASE TABLE'
@@ -38,21 +38,28 @@
     {% set vacuumable_tables=run_query(vacuumable_tables_sql) %}
 
     {% for row in vacuumable_tables %}
+        {% set message_prefix=loop.index ~ " of " ~ loop.length %}
+
         {%- set relation_to_vacuum = adapter.get_relation(
                                                 database=row['table_database'],
                                                 schema=row['table_schema'],
                                                 identifier=row['table_name']
                                     ) -%}
         {% do run_query("commit") %}
-        {% set start=modules.datetime.datetime.now() %}
-        {% set message_prefix=loop.index ~ " of " ~ loop.length %}
-        {{ dbt_utils.log_info(message_prefix ~ " Vacuuming " ~ relation_to_vacuum) }}
-        {% do run_query("vacuum " ~ relation_to_vacuum) %}
-        {{ dbt_utils.log_info(message_prefix ~ " Analyzing " ~ relation_to_vacuum) }}
-        {% do run_query("analyze " ~ relation_to_vacuum) %}
-        {% set end=modules.datetime.datetime.now() %}
-        {% set total_seconds = (end - start).total_seconds() | round(2)  %}
-        {{ dbt_utils.log_info(message_prefix ~ " Finished " ~ relation_to_vacuum ~ " in " ~ total_seconds ~ "s") }}
+
+        {% if relation_to_vacuum %}
+            {% set start=modules.datetime.datetime.now() %}
+            {{ dbt_utils.log_info(message_prefix ~ " Vacuuming " ~ relation_to_vacuum) }}
+            {% do run_query("vacuum " ~ relation_to_vacuum) %}
+            {{ dbt_utils.log_info(message_prefix ~ " Analyzing " ~ relation_to_vacuum) }}
+            {% do run_query("analyze " ~ relation_to_vacuum) %}
+            {% set end=modules.datetime.datetime.now() %}
+            {% set total_seconds = (end - start).total_seconds() | round(2)  %}
+            {{ dbt_utils.log_info(message_prefix ~ " Finished " ~ relation_to_vacuum ~ " in " ~ total_seconds ~ "s") }}
+        {% else %}
+            {{ dbt_utils.log_info(message_prefix ~ ' Relation "' ~ row.values() | join ('"."') ~ '" does not exist') }}
+        {% endif %}
+
     {% endfor %}
 
 {% endmacro %}


### PR DESCRIPTION
Improvements to the `redshift_maintenance` macro, namely:
* Ability to add a version of `vacuumable_tables_sql` to your own project to override the default
* Confirm the existence of a relation before trying to vacuum it -- previously if a relation was dropped in the time between generating the list of tables, and vacuuming the relation, you'd hit a database error and the whole job would error out. We're now avoiding that scenario.