### PR TITLE
Fix/qualify base model schemas

### DIFF
--- a/models/base/pg_attribute.sql
+++ b/models/base/pg_attribute.sql
@@ -27,4 +27,4 @@ select
 , (case attsortkeyord
         when 1 then attname
         else null end) as sort_key
-from pg_attribute
+from pg_catalog.pg_attribute

--- a/models/base/pg_class.sql
+++ b/models/base/pg_class.sql
@@ -30,4 +30,4 @@ select
 , relhasrules
 , relhassubclass
 , relacl
-from pg_class
+from pg_catalog.pg_class

--- a/models/base/pg_depend.sql
+++ b/models/base/pg_depend.sql
@@ -6,4 +6,4 @@ select
 , refobjid
 , refobjsubid
 , deptype
-from pg_depend
+from pg_catalog.pg_depend

--- a/models/base/pg_namespace.sql
+++ b/models/base/pg_namespace.sql
@@ -3,4 +3,4 @@ select
 , nspname
 , nspowner
 , nspacl
-from pg_namespace
+from pg_catalog.pg_namespace

--- a/models/base/pg_tables.sql
+++ b/models/base/pg_tables.sql
@@ -6,4 +6,4 @@ select
 , hasindexes as has_indexes
 , hasrules as has_rules
 , hastriggers as has_triggers
-from pg_tables
+from pg_catalog.pg_tables

--- a/models/base/pg_user.sql
+++ b/models/base/pg_user.sql
@@ -3,4 +3,4 @@ select
   usesysid as user_id
 , usename as username
 
-from pg_user
+from pg_catalog.pg_user

--- a/models/base/pg_views.sql
+++ b/models/base/pg_views.sql
@@ -2,4 +2,4 @@ select
   schemaname as schema_name
 , viewname as view_name
 , viewowner as view_owner
-from pg_views
+from pg_catalog.pg_views

--- a/models/base/stl_explain.sql
+++ b/models/base/stl_explain.sql
@@ -7,4 +7,4 @@ select
 , plannode
 , info
 
-from stl_explain
+from pg_catalog.stl_explain

--- a/models/base/stl_query.sql
+++ b/models/base/stl_query.sql
@@ -10,4 +10,4 @@ select
 , endtime as finished_at
 , aborted
 
-from stl_query
+from pg_catalog.stl_query

--- a/models/base/stl_wlm_query.sql
+++ b/models/base/stl_wlm_query.sql
@@ -16,4 +16,4 @@ select
 , service_class_end_time
 , final_state
 
-from stl_wlm_query
+from pg_catalog.stl_wlm_query

--- a/models/base/stv_blocklist.sql
+++ b/models/base/stv_blocklist.sql
@@ -21,4 +21,4 @@ select
 , num_readers
 , id
 , flags
-from stv_blocklist
+from pg_catalog.stv_blocklist

--- a/models/base/stv_partitions.sql
+++ b/models/base/stv_partitions.sql
@@ -1,0 +1,20 @@
+select
+
+  owner
+, host
+, diskno
+, part_begin
+, part_end
+, used
+, tossed
+, capacity
+, "reads"
+, writes
+, seek_forward
+, seek_back
+, is_san
+, failed
+, mbps
+, mount
+
+from pg_catalog.stv_partitions

--- a/models/base/stv_tbl_perm.sql
+++ b/models/base/stv_tbl_perm.sql
@@ -8,4 +8,4 @@ select
 , temp
 , db_id
 , backup
-from stv_tbl_perm
+from pg_catalog.stv_tbl_perm

--- a/models/base/svv_diskusage.sql
+++ b/models/base/svv_diskusage.sql
@@ -23,4 +23,4 @@ select
 , num_readers
 , id
 , flags
-from svv_diskusage
+from pg_catalog.svv_diskusage

--- a/models/views/redshift_admin_table_stats.sql
+++ b/models/views/redshift_admin_table_stats.sql
@@ -52,8 +52,7 @@ with unsorted_by_table as (
 
   select
     sum(capacity) as total_megabytes
-  from
-  stv_partitions
+  from {{ref('stv_partitions')}}
   where part_begin=0
 
 ), table_distribution_ratio as (


### PR DESCRIPTION
This PR adds the `pg_catalog` schema to all the base models to cope with the requirement of "late binding views" (with no schema binding) that all objects must be qualified by schema, e.g. `from <schema>.<objectname>` rather than just `from <objectname>`

see  https://github.com/fishtown-analytics/redshift/issues/26 

For consistency, I also added a base model `stv_partitions` , because the underlying system view was being directly referenced by the `redshift_admin_table_stats` view.

**Testing**

All of the models in the `./base` directory are `ephemeral` as specified in the `dbt_project.yml` file, so they aren't directly tested by their instantiation, however, all of these base models are referenced by models in the `./views` directory in this package which are instantiated. These views are effectively serving as integration tests when they are run. 

I ran this both with a global `bind: false` (all views will be created without schema binding) in the `dbt_project.yml` file and without, and it now runs successfully with that specification.
