### PR TITLE
add drop dev / sinter schemas macro

### DIFF
--- a/macros/drop_dev_and_sinter_schemas.sql
+++ b/macros/drop_dev_and_sinter_schemas.sql
@@ -1,0 +1,57 @@
+{% macro drop_dev_schemas(schema_ilike = ['dbt%', 'sinter%', 'dev%'], dry_run = true, exclude = '') %} 
+
+{% set get_dev_sql %}
+
+    select 
+        distinct schemaname
+    from pg_catalog.pg_tables 
+    where 
+    (
+        (
+        
+        {% for schema in schema_ilike %} 
+
+        schemaname ilike '{{schema}}' {{'or' if not loop.last}} 
+
+        {% endfor %}
+        
+    )
+        and 
+        (
+            
+        
+        {% for schema in schema_ilike %} 
+        
+        schemaname not ilike '{{ exclude }}' {{'or' if not loop.last}} 
+        
+        {% endfor %}
+    
+    )
+        
+    )
+{% endset %}
+
+
+{% set dev_schemas = dbt_utils.get_query_results_as_dict(get_dev_sql) %}
+
+{% for schema_name in dev_schemas['schemaname'] %} 
+
+    {% set drop_schema -%} 
+    
+        drop schema {{schema_name}} cascade;
+
+    {%- endset %}
+    
+    {% if dry_run %} 
+    
+        {{ log(drop_schema, info=True) }} 
+
+    {% else %}
+
+        {% do run_query(drop_schema) %}
+
+    {% endif %}
+
+{% endfor %}
+
+{% endmacro %}


### PR DESCRIPTION
## Addition of a macro that would drop any development or sinter schemas:

- Multiple users have found the need to run a script/job that drops any development and/or sinter schemas because of space constraints in Redshift. 
- This macro would drop schema names similar to 'sinter' ,'dbt', or 'dev' .
- The dry run argument is set to true as the default, and the macro also takes an exclude argument. In the event of a dry run, the macro will simply log the results of the query instead of executing it. 

cc : @ChrisLawliss 