### PR TITLE
README points to incorrect hub.getdbt page

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Installation instructions
 
-1. Include this package in your `packages.yml` -- check [here](https://hub.getdbt.com/fishtown-analytics/segment/latest/)
+1. Include this package in your `packages.yml` -- check [here](https://hub.getdbt.com/fishtown-analytics/redshift/latest/)
 for installation instructions.
 2. Run `dbt deps`
 


### PR DESCRIPTION
## Description & motivation
The README points to the Segment hub page currently

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)