### PR TITLE
Support dbt_utils 0.5.x

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: fishtown-analytics/dbt_utils
-    version: [">=0.1.25", "<0.5.0"]
+    version: [">=0.1.25", "<0.6.0"]


### PR DESCRIPTION


## Description & motivation

There doesn't seem to be anything in 0.5.0 which breaks compatibility with this package.

As this just uses logging, it might be preferable to remove the upper bound for now, more of a maintainers decision.

## Checklist
- [x] I have verified that these changes work locally
- ~I have updated the README.md (if applicable)~
- ~I have added tests & descriptions to my models (and macros if applicable)~