### PR TITLE
Add PARTITION BY to the unload macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,9 @@ Macro signature:
                 add_quotes=Boolean,
                 encrypted=Boolean,
                 overwrite=Boolean,
-                parallel=Boolean) }}
+                parallel=Boolean,
+                partition_by=none|List<String>
+) }}
 ```
 
 Example usage:

--- a/macros/unload.sql
+++ b/macros/unload.sql
@@ -6,14 +6,13 @@ authorization
 [ option [ ... ] ]
 
 where option is
-
-{ MANIFEST [ VERBOSE ] 
-| HEADER
-
-| [ FORMAT [AS] ] CSV
+{ [ FORMAT [ AS ] ] CSV | PARQUET
+| PARTITION BY ( column_name [, ... ] ) [ INCLUDE ]
+| MANIFEST [ VERBOSE ] 
+| HEADER           
 | DELIMITER [ AS ] 'delimiter-char' 
-| FIXEDWIDTH [ AS ] 'fixedwidth-spec' }  
-| ENCRYPTED
+| FIXEDWIDTH [ AS ] 'fixedwidth-spec'   
+| ENCRYPTED [ AUTO ]
 | BZIP2  
 | GZIP 
 | ZSTD
@@ -22,8 +21,8 @@ where option is
 | ESCAPE
 | ALLOWOVERWRITE
 | PARALLEL [ { ON | TRUE } | { OFF | FALSE } ]
-| MAXFILESIZE [AS] max-size [ MB | GB ] ]
-| REGION [AS] 'aws-region'
+| MAXFILESIZE [AS] max-size [ MB | GB ] 
+| REGION [AS] 'aws-region' }
 
 #}
 -- Unloads a Redshift table to S3
@@ -45,7 +44,9 @@ where option is
                 add_quotes=False,
                 encrypted=False,
                 overwrite=False,
-                parallel=False) %}
+                parallel=False,
+                partition_by=None
+                ) %}
 
   -- compile UNLOAD statement
   UNLOAD ('SELECT * FROM "{{ schema }}"."{{ table }}"')
@@ -94,5 +95,7 @@ where option is
   {% if aws_region %}
   REGION '{{ aws_region }}'
   {% endif %}
-
+  {% if partition_by %}
+  PARTITION BY ( {{ partition_by | join(', ') }} )
+  {% endif %}
 {% endmacro %}


### PR DESCRIPTION
## Description & motivation
<!---
Describe your changes, and why you're making them.
-->
PARTITION BY is currently not supported by the unload macro.
In this PR, I add support for PARTITION BY.

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)